### PR TITLE
Address some TODOs

### DIFF
--- a/goaci.go
+++ b/goaci.go
@@ -19,9 +19,13 @@ import (
 
 var Debug bool
 
-func die(s string, i ...interface{}) {
+func warn(s string, i ...interface{}) {
 	s = fmt.Sprintf(s, i...)
 	fmt.Fprintln(os.Stderr, strings.TrimSuffix(s, "\n"))
+}
+
+func die(s string, i ...interface{}) {
+	warn(s, i...)
 	os.Exit(1)
 }
 
@@ -62,10 +66,10 @@ func main() {
 	flag.StringVar(&goBinaryOpt, "go-binary", gocmd, goDefaultBinaryDesc)
 	flag.Parse()
 	if os.Getenv("GOPATH") != "" {
-		die("to avoid confusion GOPATH must not be set")
+		warn("GOPATH envvar is ignored")
 	}
 	if os.Getenv("GOROOT") != "" {
-		die("to avoid confusion GOROOT must not be set, use --go-binary=\"$GOROOT/bin/go\" option instead")
+		warn("GOROOT envvar is ignored, use --go-binary=\"$GOROOT/bin/go\" option instead")
 	}
 	if os.Getenv("GOACI_DEBUG") != "" {
 		Debug = true

--- a/goaci.go
+++ b/goaci.go
@@ -78,7 +78,6 @@ func main() {
 	}
 
 	// Construct args for a go get that does a static build
-	// TODO(jonboulle): go version 1.4
 	args := []string{
 		gocmd,
 		"get",

--- a/goaci.go
+++ b/goaci.go
@@ -102,6 +102,7 @@ func main() {
 	if err != nil {
 		die("bad app name: %v", err)
 	}
+	args = append(args, ns)
 
 	// Use the last component, e.g. example.com/my/app --> app
 	ofn := filepath.Base(ns) + ".aci"

--- a/goaci.go
+++ b/goaci.go
@@ -68,10 +68,11 @@ func main() {
 	flag.StringVar(&goPathOpt, "go-path", "", "Custom GOPATH (default: a temporary directory)")
 	flag.Parse()
 	if os.Getenv("GOPATH") != "" {
-		warn("GOPATH envvar is ignored, use --go-path=\"$GOPATH\" option instead")
+		warn("GOPATH env var is ignored, use --go-path=\"$GOPATH\" option instead")
 	}
-	if os.Getenv("GOROOT") != "" {
-		warn("GOROOT envvar is ignored, use --go-binary=\"$GOROOT/bin/go\" option instead")
+	goRoot := os.Getenv("GOROOT")
+	if goRoot != "" {
+		warn("Overriding GOROOT env var to %s", goRoot)
 	}
 	if os.Getenv("GOACI_DEBUG") != "" {
 		Debug = true
@@ -131,13 +132,17 @@ func main() {
 		die("error opening output file: %v", err)
 	}
 
+	env := []string{
+		"GOPATH=" + goPathOpt,
+		"GOBIN=" + gobin,
+		"CGO_ENABLED=0",
+		"PATH=" + os.Getenv("PATH"),
+	}
+	if goRoot != "" {
+		env = append(env, "GOROOT="+goRoot)
+	}
 	cmd := exec.Cmd{
-		Env: []string{
-			"GOPATH=" + goPathOpt,
-			"GOBIN=" + gobin,
-			"CGO_ENABLED=0",
-			"PATH=" + os.Getenv("PATH"),
-		},
+		Env:    env,
 		Path:   goBinaryOpt,
 		Args:   args,
 		Stderr: os.Stderr,


### PR DESCRIPTION
So far three of them are addressed - about specifying arguments to exec, about setting custom GOPATH and about doing static builds for go-1.4.

This also addresses #1 - GOROOT and GOPATH env vars are ignored.

The third one is problematic from distro point of view - if using go provided by distro (Fedora 21 in my case), then goaci can fail with following message:
go install runtime: mkdir /usr/lib/golang/pkg/linux_amd64_netgo/: permission denied

Not sure if there's a way to specify different pkg directory where libs could be stored. GOPKG env var would be cool (like GOBIN). Specifying installsuffix to something like /tmp/goaci-XXXXXX/netgo resulted in:
go install runtime: mkdir /usr/lib/golang/pkg/linux_amd64_: permission denied

I suppose running goaci for the first time as root might "fix" it, but it's messy - I haven't tried that.

In the meantime I fixed the "go get" command invocation - the package name (github.com/coreos/etcd) wasn't passed there, so go get was actually getting the package from current working directory.

Next step could be addressing the "// TODO(jonboulle): support multiple executables?", but the code now needs refactoring. Currently, almost everything is just in main function.
