### PR TITLE
recursively search parent directory for vcs directory

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -5,17 +5,23 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 )
 
 func repoDirExists(projPath, repoDir string) bool {
-	path := filepath.Join(projPath, repoDir)
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
+	for ; projPath != path.Dir(projPath); projPath = path.Dir(projPath) {
+		path := filepath.Join(projPath, repoDir)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			return true
+		}
 	}
-	return info.IsDir()
+	return false
 }
 
 // getId gets first line of commands output which should hold some VCS


### PR DESCRIPTION
`go get` would clone the repo automatically but the VCS directory (e.g. `.git`) would always be in the root directory. If a project's binary is in a sub-directory, `goaci` could not find the `.git` thus fails to recognize the VCS repo. This commit adds support for projects where binaries stay in subdirectories of the project repo by recursively search parent directories for the VCS directory.
